### PR TITLE
Debug CFBD CSV cache deployment issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,6 @@ RUN pip install --no-cache-dir --upgrade pip \
     && yt-dlp --version
 
 COPY ./app /app/app
+COPY ./data /app/data
 
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
The CSV cache files were generated by GitHub Actions and committed to the repository at data/cfb_plays/, but the Dockerfile only copied the ./app directory, leaving /app/data/ missing in the Railway container.

This caused cache lookups to fail and jobs to fall back to timegrid instead of using real play data.

Solution: Copy ./data directory into the Docker image so the 264 cached CSV files (8.7MB) are available at /app/data/cfb_plays/ in the container.

Resolves the Railway deployment issue where cached play data was inaccessible despite being present in the repository.