### PR TITLE
Fix API format error in Vision Play Mapper

### DIFF
--- a/app/vision_play_mapper.py
+++ b/app/vision_play_mapper.py
@@ -632,7 +632,14 @@ RESPOND WITH ONLY A JSON OBJECT:
 Only include plays you can identify with at least medium confidence."""
 
         # Prepare messages for Claude
-        frame_messages = [frame["source"] for frame in frame_data]
+        # IMPORTANT: Must use proper image format with "type": "image" at top level
+        frame_messages = [
+            {
+                "type": "image",
+                "source": frame["source"]
+            }
+            for frame in frame_data
+        ]
 
         try:
             # Log plays we're looking for (preview first few)


### PR DESCRIPTION
Fixed API format validation error caused by incorrect content block structure.

Issue: Vision Play Mapper was sending frames with `{"type": "base64", ...}`
instead of proper image format `{"type": "image", "source": {...}}`.

Error message:
```
messages.0.content.0: Input tag 'base64' found using 'type'
does not match any of the expected tags: 'image', 'document', etc.
```

Fix:
- Changed line 635 from extracting just `frame["source"]` to constructing proper image content blocks
- Now sends: `{"type": "image", "source": {"type": "base64", ...}}`
- This matches the expected Anthropic API format

Impact:
- Fixes API validation errors that occurred after 413 payload fix
- Vision Play Mapper can now successfully call Claude Vision API
- 413 errors remain fixed (~48 frames × 75 KB = ~3.5 MB payload)

Reference: app/vision_play_mapper.py:635-642